### PR TITLE
fixing "contact us" page link

### DIFF
--- a/registrationpage.php
+++ b/registrationpage.php
@@ -32,7 +32,7 @@ require_once("partial/header.php");
                                         </div>
                                         <div class="text-center">
                                         <button type="submit" class="btn btn-danger">Join Us </button>
-						<p><a href="/contactUS">contact us</a></p>
+						<p><a href="contactUS">contact us</a></p>
 										</div>
                                     </form>
                                     <div class="clearfix"></div>


### PR DESCRIPTION
Replacing the "/"by quotes in the "contactUS" page link