### PR TITLE
refactor tabmenu

### DIFF
--- a/partial/header.php
+++ b/partial/header.php
@@ -12,6 +12,9 @@
 
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
+
 	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 	

--- a/tabmenu.php
+++ b/tabmenu.php
@@ -1,125 +1,127 @@
+<div id="accordion"
 <div class="container bg-white px-0" style="line-height: 0.5 !important;" `>
-  <!-- Nav tabs -->
-  <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item bg-light">
-      <a class="nav-link active font-weight-bold text-info" data-toggle="tab" href="#activetab">Active</a>
-    </li>
-    <li class="nav-item bg-light">
-      <a class="nav-link font-weight-bold text-info" data-toggle="tab" href="#newtab">New</a>
-    </li>
-    <li class="nav-item bg-light">
-      <a class="nav-link font-weight-bold text-success" data-toggle="tab" href="#unansweredtab">Unanswered</a>
-    </li>
-  </ul>
+	<!-- Nav tabs -->
+	<ul class="nav nav-tabs" role="tablist">
+		<li class="nav-item bg-light">
+			<a class="nav-link active font-weight-bold text-info" data-toggle="collapse" href="#activetab">Active</a>
+		</li>
+		<li class="nav-item bg-light">
+			<a class="nav-link font-weight-bold text-info" data-toggle="collapse" href="#newtab">New</a>
+		</li>
+		<li class="nav-item bg-light">
+			<a class="nav-link font-weight-bold text-success" data-toggle="collapse" href="#unansweredtab">Unanswered</a>
+		</li>
+	</ul>
 
-  <!-- Tab panes -->
-  <div class="tab-content">
-    <div id="activetab" class="container tab-pane active"><br>
-      <div class="container">
-        <!-- Table of posts -->
-        <div >
-          <!-- Single post that is added to the homepage starts here -->
-          <div class="row border-bottom border-gray">    
-            <div class="col">
-              <h5 class="row my-1">Aon mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo ?</h5>
-              <div class="my-1 text-muted small row">
-                <p class="m-0">
-                  <strong class="text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 70&emsp;</span><span style="color: blue;">Likes: 26</span>&emsp;Posted: 2 hours ago</strong>
-                </p>
-              </div>
-            </div>
-          </div>
-          <!-- End of single post -->
-          <div class="row border-bottom border-gray">
-            <div class="col">
-              <h5 class="row my-1">Non mi porta gravida at eget metus. Fusce dapibus?</h5>
-              <div class="my-1 text-muted small row">
-                <p class="m-0">
-                  <strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 6&emsp;</span><span style="color: blue;">Likes: 20</span>&emsp;Posted: 1 day ago</strong>
-                </p>
-              </div>
-            </div>
-          </div>
-          <div class="row border-bottom border-gray">
-          <div class="col">
-            <h5 class="row my-1">Non mi porta gravida at eget metus?</h5>
-            <div class="my-1 text-muted row">
-              <p class="small m-0">
-                <strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 18&emsp;</span><span style="color: blue;">Likes: 43</span>&emsp;Posted: 12 hours ago</strong>
-              </p>
-            </div></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div id="newtab" class="container tab-pane fade"><br>
-     <div class="container">
-      <!-- Table of posts -->
-      <div>
-        <!-- Single post that is added to the homepage starts here -->
-        <div class="row border-bottom border-gray">
-        <div class="col">
-          <h5 class="row">Non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus?</h5>
-          <div class="my-1 text-muted row">
-            <p class="small m-0">
-              <strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 2&emsp;</span><span style="color: blue;">Likes: 5</span>&emsp;Posted: Just now</strong>
-            </p>
-          </div></div>
-        </div>
-        <!-- End of single post -->
-        <div class="row border-bottom border-gray"><div class="col">
-          <h5 class="row">Fusce dapibus, tellus ac cursus commodo?</h5>
-          <div class="my-1 text-muted row">
-            <p class="small m-0">
-              <strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 6&emsp;</span><span style="color: blue;">Likes: 20</span>&emsp;Posted: 15 minutes ago</strong>
-            </p>
-          </div></div>
-        </div>
-        <div class="row border-bottom border-gray"><div class="col">
-          <h5 class="row">Non mi porta gravida at eget metus. Tellus ac cursus commodo?</h5>
-          <div class="my-1 text-muted row">
-            <p class="small m-0">
-              <strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 18&emsp;</span><span style="color: blue;">Likes: 43</span>&emsp;Posted: 1 hour ago</strong>
-            </p>
-          </div></div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div id="unansweredtab" class="container tab-pane fade"><br>
-   <div class="container">
-    <!-- Table of posts -->
-    <div>
-      <!-- Single post that is added to the homepage starts here -->
-      <div class="row border-bottom border-gray"><div class="col">
-        <h5 class="row">Non mi porta gravida at eget metus?</h5>
-        <div class="my-1 text-muted row">
-          <p class="small m-0">
-            <strong class="d-block text-gray-dark">From: flower<span style="color: green;">&emsp;Answers: 0&emsp;</span><span style="color: blue;">Likes: 125</span>&emsp;Posted: 15 hours ago</strong>
-          </p>
-        </div></div>
-      </div>
-      <!-- End of single post -->
-      <div class="row border-bottom border-gray"><div class="col">
-        <h5 class="row">Gravida at eget metus. Fusce dapibus, tellus ac cursus commodo?</h5>
-        <div class="my-1 text-muted row">
-          <p class="small m-0">
-            <strong class="d-block text-gray-dark">From: amazingtrainer<span style="color: green;">&emsp;Answers: 0&emsp;</span><span style="color: blue;">Likes: 125</span>&emsp;Posted: 3 days ago</strong>
-          </p>
-        </div></div>
-        <p></p>
-      </div>
-      <div class="row border-bottom border-gray"><div class="col">
-        <h5 class="row">Porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo?</h5>
-        <div class="my-1 text-muted row">
-          <p class="small m-0">
-            <strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 0&emsp;</span><span style="color: blue;">Likes: 125</span>&emsp;Posted: 5 hours ago</strong>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-</div>
-</div>
+	<!-- Tab panes -->
+	<div class="tab-content">
+		<div id="activetab" class="container collapse" data-parent="#accordion"><br>
+			<div class="container">
+				<!-- Table of posts -->
+				<div >
+					<!-- Single post that is added to the homepage starts here -->
+					<div class="row border-bottom border-gray">    
+						<div class="col">
+							<h5 class="row my-1">Aon mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo ?</h5>
+							<div class="my-1 text-muted small row">
+								<p class="m-0">
+									<strong class="text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 70&emsp;</span><span style="color: blue;">Likes: 26</span>&emsp;Posted: 2 hours ago</strong>
+								</p>
+							</div>
+						</div>
+					</div>
+					<!-- End of single post -->
+					<div class="row border-bottom border-gray">
+						<div class="col">
+							<h5 class="row my-1">Non mi porta gravida at eget metus. Fusce dapibus?</h5>
+							<div class="my-1 text-muted small row">
+								<p class="m-0">
+									<strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 6&emsp;</span><span style="color: blue;">Likes: 20</span>&emsp;Posted: 1 day ago</strong>
+								</p>
+							</div>
+						</div>
+					</div>
+					<div class="row border-bottom border-gray">
+						<div class="col">
+							<h5 class="row my-1">Non mi porta gravida at eget metus?</h5>
+							<div class="my-1 text-muted row">
+								<p class="small m-0">
+									<strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 18&emsp;</span><span style="color: blue;">Likes: 43</span>&emsp;Posted: 12 hours ago</strong>
+								</p>
+							</div></div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div id="newtab" class="container collapse" data-parent="#accordion"><br>
+				<div class="container">
+					<!-- Table of posts -->
+					<div>
+						<!-- Single post that is added to the homepage starts here -->
+						<div class="row border-bottom border-gray">
+							<div class="col">
+								<h5 class="row">Non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus?</h5>
+								<div class="my-1 text-muted row">
+									<p class="small m-0">
+										<strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 2&emsp;</span><span style="color: blue;">Likes: 5</span>&emsp;Posted: Just now</strong>
+									</p>
+								</div></div>
+							</div>
+							<!-- End of single post -->
+							<div class="row border-bottom border-gray"><div class="col">
+								<h5 class="row">Fusce dapibus, tellus ac cursus commodo?</h5>
+								<div class="my-1 text-muted row">
+									<p class="small m-0">
+										<strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 6&emsp;</span><span style="color: blue;">Likes: 20</span>&emsp;Posted: 15 minutes ago</strong>
+									</p>
+								</div></div>
+							</div>
+							<div class="row border-bottom border-gray"><div class="col">
+								<h5 class="row">Non mi porta gravida at eget metus. Tellus ac cursus commodo?</h5>
+								<div class="my-1 text-muted row">
+									<p class="small m-0">
+										<strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 18&emsp;</span><span style="color: blue;">Likes: 43</span>&emsp;Posted: 1 hour ago</strong>
+									</p>
+								</div></div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div id="unansweredtab" class="container collapse" data-parent="#accordion"><br>
+					<div class="container">
+						<!-- Table of posts -->
+						<div>
+							<!-- Single post that is added to the homepage starts here -->
+							<div class="row border-bottom border-gray"><div class="col">
+								<h5 class="row">Non mi porta gravida at eget metus?</h5>
+								<div class="my-1 text-muted row">
+									<p class="small m-0">
+										<strong class="d-block text-gray-dark">From: flower<span style="color: green;">&emsp;Answers: 0&emsp;</span><span style="color: blue;">Likes: 125</span>&emsp;Posted: 15 hours ago</strong>
+									</p>
+								</div></div>
+							</div>
+							<!-- End of single post -->
+							<div class="row border-bottom border-gray"><div class="col">
+								<h5 class="row">Gravida at eget metus. Fusce dapibus, tellus ac cursus commodo?</h5>
+								<div class="my-1 text-muted row">
+									<p class="small m-0">
+										<strong class="d-block text-gray-dark">From: amazingtrainer<span style="color: green;">&emsp;Answers: 0&emsp;</span><span style="color: blue;">Likes: 125</span>&emsp;Posted: 3 days ago</strong>
+									</p>
+								</div></div>
+								<p></p>
+							</div>
+							<div class="row border-bottom border-gray"><div class="col">
+								<h5 class="row">Porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo?</h5>
+								<div class="my-1 text-muted row">
+									<p class="small m-0">
+										<strong class="d-block text-gray-dark">From: Username<span style="color: green;">&emsp;Answers: 0&emsp;</span><span style="color: blue;">Likes: 125</span>&emsp;Posted: 5 hours ago</strong>
+									</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>


### PR DESCRIPTION
added two lines to header in order to make tab toggle work.

tabmenu was made collapsible in order to not take up page space when it is not needed in certain pages (sign in, sign up, contact us, etc). Tab elements were switch out for collapse instead. Parent-data feature was added so the previous tab would retract before the next would open.

#87 