### PR TITLE
MySQLrequest code for unpopular changed to query for least number of responses

### DIFF
--- a/action/dba/MySQLrequests.php
+++ b/action/dba/MySQLrequests.php
@@ -422,7 +422,7 @@ class MySQLRequests {
 
 	public static function getUnpopularPost(){
 		$connection=connection::getConnection();
-		$statement = $connection->prepare("SELECT * FROM post ORDER BY post_id ASC LIMIT 3");
+		$statement = $connection->prepare("SELECT * FROM post ORDER BY post_nb_answers ASC LIMIT 3");
 		$statement->setFetchMode(PDO::FETCH_ASSOC);
 		$statement->execute();
 		$info = $statement->fetchAll();


### PR DESCRIPTION


Before the questions were queried based on their post id, which gave the wrong matches to the questions.

Changes were made accordingly to query matches based on the least number of answers